### PR TITLE
bus window with doubleclick, load symbol

### DIFF
--- a/resources/ui/add_bus.ui
+++ b/resources/ui/add_bus.ui
@@ -6,113 +6,151 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>899</width>
-    <height>411</height>
+    <width>852</width>
+    <height>467</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Add Bus</string>
   </property>
-  <widget class="QPushButton" name="add_bus">
+  <widget class="QTabWidget" name="tabWidget">
    <property name="geometry">
     <rect>
-     <x>20</x>
-     <y>10</y>
-     <width>75</width>
+     <x>0</x>
+     <y>0</y>
+     <width>851</width>
+     <height>421</height>
+    </rect>
+   </property>
+   <property name="currentIndex">
+    <number>0</number>
+   </property>
+   <widget class="QWidget" name="tab">
+    <attribute name="title">
+     <string>Parameters</string>
+    </attribute>
+    <widget class="QLabel" name="vn_kv_label">
+     <property name="geometry">
+      <rect>
+       <x>15</x>
+       <y>14</y>
+       <width>47</width>
+       <height>13</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>vn_kv</string>
+     </property>
+    </widget>
+    <widget class="QTextEdit" name="vn_kv">
+     <property name="geometry">
+      <rect>
+       <x>48</x>
+       <y>12</y>
+       <width>51</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="inputMethodHints">
+      <set>Qt::ImhDigitsOnly</set>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="acceptRichText">
+      <bool>true</bool>
+     </property>
+    </widget>
+    <widget class="QLabel" name="name_label">
+     <property name="geometry">
+      <rect>
+       <x>14</x>
+       <y>40</y>
+       <width>47</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>name</string>
+     </property>
+    </widget>
+    <widget class="QTextEdit" name="name">
+     <property name="geometry">
+      <rect>
+       <x>50</x>
+       <y>40</y>
+       <width>171</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="inputMethodHints">
+      <set>Qt::ImhNone</set>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
+   </widget>
+   <widget class="QWidget" name="tab_2">
+    <attribute name="title">
+     <string>Documentation</string>
+    </attribute>
+    <widget class="QWebView" name="webView_2">
+     <property name="geometry">
+      <rect>
+       <x>640</x>
+       <y>0</y>
+       <width>201</width>
+       <height>391</height>
+      </rect>
+     </property>
+     <property name="url">
+      <url>
+       <string>http://pandapower.readthedocs.io/en/v1.3.0/_images/bus.png</string>
+      </url>
+     </property>
+    </widget>
+    <widget class="QWebView" name="webView">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>10</y>
+       <width>611</width>
+       <height>381</height>
+      </rect>
+     </property>
+     <property name="url">
+      <url>
+       <string>http://pandapower.readthedocs.io/en/v1.3.0/elements/bus.html#bus</string>
+      </url>
+     </property>
+    </widget>
+   </widget>
+  </widget>
+  <widget class="QPushButton" name="ok">
+   <property name="geometry">
+    <rect>
+     <x>6</x>
+     <y>429</y>
+     <width>80</width>
      <height>23</height>
     </rect>
    </property>
    <property name="text">
-    <string>Add Bus</string>
+    <string>OK</string>
    </property>
   </widget>
-  <widget class="QTextEdit" name="vn_kv">
+  <widget class="QPushButton" name="cancel">
    <property name="geometry">
     <rect>
-     <x>140</x>
-     <y>10</y>
-     <width>171</width>
-     <height>31</height>
-    </rect>
-   </property>
-  </widget>
-  <widget class="QTextEdit" name="name">
-   <property name="geometry">
-    <rect>
-     <x>140</x>
-     <y>50</y>
-     <width>171</width>
-     <height>31</height>
-    </rect>
-   </property>
-  </widget>
-  <widget class="QLabel" name="vn_kv_label">
-   <property name="geometry">
-    <rect>
-     <x>110</x>
-     <y>10</y>
-     <width>47</width>
-     <height>13</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>vn_kv</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="name_label">
-   <property name="geometry">
-    <rect>
-     <x>110</x>
-     <y>40</y>
-     <width>47</width>
-     <height>13</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>name</string>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="edit_bus">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>40</y>
-     <width>75</width>
+     <x>86</x>
+     <y>429</y>
+     <width>80</width>
      <height>23</height>
     </rect>
    </property>
    <property name="text">
-    <string>Edit Bus</string>
-   </property>
-  </widget>
-  <widget class="QWebView" name="webView">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>90</y>
-     <width>651</width>
-     <height>341</height>
-    </rect>
-   </property>
-   <property name="url">
-    <url>
-     <string>http://pandapower.readthedocs.io/en/v1.3.0/elements/bus.html#bus</string>
-    </url>
-   </property>
-  </widget>
-  <widget class="QWebView" name="webView_2">
-   <property name="geometry">
-    <rect>
-     <x>680</x>
-     <y>10</y>
-     <width>201</width>
-     <height>391</height>
-    </rect>
-   </property>
-   <property name="url">
-    <url>
-     <string>http://pandapower.readthedocs.io/en/v1.3.0/_images/bus.png</string>
-    </url>
+    <string>Cancel</string>
    </property>
   </widget>
  </widget>

--- a/resources/ui/builder.ui
+++ b/resources/ui/builder.ui
@@ -1159,7 +1159,7 @@
      <rect>
       <x>110</x>
       <y>10</y>
-      <width>221</width>
+      <width>131</width>
       <height>441</height>
      </rect>
     </property>
@@ -1174,22 +1174,9 @@
      </rect>
     </property>
     <property name="title">
-     <string>GroupBox</string>
+     <string>Create</string>
     </property>
     <widget class="QRadioButton" name="Bus">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>20</y>
-       <width>82</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Bus</string>
-     </property>
-    </widget>
-    <widget class="QRadioButton" name="Line">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -1199,10 +1186,10 @@
       </rect>
      </property>
      <property name="text">
-      <string>Line</string>
+      <string>Create Bus</string>
      </property>
     </widget>
-    <widget class="QRadioButton" name="Trafo">
+    <widget class="QRadioButton" name="Line">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -1212,7 +1199,36 @@
       </rect>
      </property>
      <property name="text">
-      <string>Trafo</string>
+      <string>Create Line</string>
+     </property>
+    </widget>
+    <widget class="QRadioButton" name="Trafo">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>110</y>
+       <width>82</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Create Trafo</string>
+     </property>
+    </widget>
+    <widget class="QRadioButton" name="Bus_2">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>20</y>
+       <width>82</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Edit Elements</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </widget>


### PR DESCRIPTION
I adapted the bus window so that it can be used to change bus parameter as well as create new buses. If "Edit Elements" is selected in the radio buttons, a double click on a bus opens the bus window, and parameters can be changed. With OK changes are saved, with cancel, they are discarded. If the radio button is on "Create Bus", a single click anywhere in the canvas opens the window to create a new bus.

Combining pick events with doubleclicks is not that simple, I got it to work now but the solution is a little hacky... maybe there will be a better solution still

Also load symbols are now displayed